### PR TITLE
Update `kaitai-maven-plugin` into version `0.1.4`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Change log for releases.
 
 # SNAPSHOT
 
+* Update [kaitai-maven-plugin](https://github.com/valery1707/kaitai-maven-plugin) into version `0.1.4`
+    * Can work with `commons-io:commons-io:2.4`
+
 # 0.1.1
 
 * Update [kaitai-maven-plugin](https://github.com/valery1707/kaitai-maven-plugin) into version `0.1.3`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ extra["isReleaseVersion"] = !version.toString().endsWith("SNAPSHOT")
 
 dependencies {
 	implementation(gradleApi())
-	implementation("name.valery1707.kaitai:kaitai-maven-plugin:0.1.3") {
+	implementation("name.valery1707.kaitai:kaitai-maven-plugin:0.1.4") {
 		exclude(group = "com.jcabi")
 	}
 

--- a/src/it/build-header.template
+++ b/src/it/build-header.template
@@ -8,7 +8,7 @@ buildscript {
 		// Replaced on copy
 		${dependencies}
 		//We depend on class-files and don't know about transitive dependencies
-		classpath("name.valery1707.kaitai:kaitai-maven-plugin:0.1.3") {
+		classpath("name.valery1707.kaitai:kaitai-maven-plugin:0.1.4") {
 			//Groovy-style: exclude(group: "com.jcabi")
 			//Kotlin-style: exclude(group = "com.jcabi")
 			${excludeJcabi}


### PR DESCRIPTION
New features:
* Work with `commons-io:commons-io:2.4`

References with #13 