### PR TITLE
Use correct source set path for 0.9+ and upgrade default to 0.10 Fixes #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("name.valery1707.kaitai:kaitai-gradle-plugin:0.1.2")
+        classpath("name.valery1707.kaitai:kaitai-gradle-plugin:0.1.3")
     }
 }
 ```
@@ -32,7 +32,7 @@ repositories {
     jcenter()
 }
 dependencies {
-    implementation("io.kaitai:kaitai-struct-runtime:0.8")
+    implementation("io.kaitai:kaitai-struct-runtime:0.10")
 }
 ```
 * Configure plugin (all params are optional)
@@ -44,20 +44,20 @@ kaitai {
 
 ## Plugin parameters
 
-| Name            | Type         | Since | Description                                                                                                             |
-|-----------------|--------------|-------|-------------------------------------------------------------------------------------------------------------------------|
-| skip            | boolean      | 0.1.0 | Skip plugin execution (don't read/validate any files, don't generate any java types).<br><br>**Default**: `false`       |
-| url             | java.net.URL | 0.1.0 | Direct link onto [KaiTai universal zip archive](http://kaitai.io/#download).<br><br>**Default**: Detected from version  |
-| version         | String       | 0.1.0 | Version of [KaiTai](http://kaitai.io/#download) library.<br><br>**Default**: `0.8`                                      |
-| cacheDir        | java.io.File | 0.1.0 | Cache directory for download KaiTai library.<br><br>**Default**: `build/tmp/kaitai-cache`                               |
+| Name            | Type         | Since | Description                                                                                                                    |
+|-----------------|--------------|-------|--------------------------------------------------------------------------------------------------------------------------------|
+| skip            | boolean      | 0.1.0 | Skip plugin execution (don't read/validate any files, don't generate any java types).<br><br>**Default**: `false`              |
+| url             | java.net.URL | 0.1.0 | Direct link onto [KaiTai universal zip archive](http://kaitai.io/#download).<br><br>**Default**: Detected from version         |
+| version         | String       | 0.1.0 | Version of [KaiTai](http://kaitai.io/#download) library.<br><br>**Default**: `0.10`                                            |
+| cacheDir        | java.io.File | 0.1.0 | Cache directory for download KaiTai library.<br><br>**Default**: `build/tmp/kaitai-cache`                                      |
 | sourceDirectory | java.io.File | 0.1.0 | Source directory with [Kaitai Struct language](http://formats.kaitai.io/) files.<br><br>**Default**: src/main/resources/kaitai |
-| includes        | String[]     | 0.1.0 | Include wildcard pattern list.<br><br>**Default**: ["*.ksy"]                                                            |
-| excludes        | String[]     | 0.1.0 | Exclude wildcard pattern list.<br><br>**Default**: []                                                                   |
-| output          | java.io.File | 0.1.0 | Target directory for generated Java source files.<br><br>**Default**: `build/generated/kaitai`                          |
-| packageName     | String       | 0.1.0 | Target package for generated Java source files.<br><br>**Default**: Trying to get project's group or `kaitai` otherwise |
-| executionTimeout| Long         | 0.1.1 | Timeout for execution operations.<br><br>**Default**: `5000` |
-| fromFileClass   | String       | 0.1.1 | Classname with custom KaitaiStream implementations for static builder `fromFile(...)`|
-| opaqueTypes     | Boolean      | 0.1.1 | Allow use opaque (external) types in ksy. See more in [documentation](http://doc.kaitai.io/user_guide.html#opaque-types).|
+| includes        | String[]     | 0.1.0 | Include wildcard pattern list.<br><br>**Default**: ["*.ksy"]                                                                   |
+| excludes        | String[]     | 0.1.0 | Exclude wildcard pattern list.<br><br>**Default**: []                                                                          |
+| output          | java.io.File | 0.1.0 | Target directory for generated Java source files.<br><br>**Default**: `build/generated/kaitai`                                 |
+| packageName     | String       | 0.1.0 | Target package for generated Java source files.<br><br>**Default**: Trying to get project's group or `kaitai` otherwise        |
+| executionTimeout| Long         | 0.1.1 | Timeout for execution operations.<br><br>**Default**: `5000`                                                                   |
+| fromFileClass   | String       | 0.1.1 | Classname with custom KaitaiStream implementations for static builder `fromFile(...)`                                          |
+| opaqueTypes     | Boolean      | 0.1.1 | Allow use opaque (external) types in ksy. See more in [documentation](http://doc.kaitai.io/user_guide.html#opaque-types).      |
 
 # Developments
 For debug on integration tests you must previously call some gradle tasks: `jar assemble pluginUnderTestMetadata`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
 
 repositories {
 	jcenter()
+	mavenLocal()
 }
 
 configure<JavaPluginConvention> {
@@ -24,7 +25,7 @@ extra["isReleaseVersion"] = !version.toString().endsWith("SNAPSHOT")
 
 dependencies {
 	implementation(gradleApi())
-	implementation("name.valery1707.kaitai:kaitai-maven-plugin:0.1.4") {
+	implementation("name.valery1707.kaitai:kaitai-maven-plugin:0.1.7-SNAPSHOT") {
 		exclude(group = "com.jcabi")
 	}
 
@@ -35,7 +36,13 @@ dependencies {
 
 tasks.withType<Test> {
 	testLogging {
-		events("passed", "skipped", "failed")
+		events("passed", "skipped", "failed")//, "standardOut", "standardError")
+
+		//showExceptions =true
+		////exceptionFormat= "full"
+		//showCauses =true
+		//showStackTraces=true
+
 	}
 }
 

--- a/src/it/build-header.template
+++ b/src/it/build-header.template
@@ -8,10 +8,15 @@ buildscript {
 		// Replaced on copy
 		${dependencies}
 		//We depend on class-files and don't know about transitive dependencies
-		classpath("name.valery1707.kaitai:kaitai-maven-plugin:0.1.4") {
+		classpath("name.valery1707.kaitai:kaitai-maven-plugin:0.1.7-SNAPSHOT") {
 			//Groovy-style: exclude(group: "com.jcabi")
 			//Kotlin-style: exclude(group = "com.jcabi")
 			${excludeJcabi}
 		}
+		//We depend on class-files and don't know about transitive dependencies
+		//classpath("name.valery1707.kaitai:kaitai-gradle-plugin:0.1.3-SNAPSHOT") {
+			
+		//}
+		//classpath(files("/home/byteit101/kaitai-gradle-plugin/build/libs/kaitai-gradle-plugin-0.1.3-SNAPSHOT.jar"))
 	}
 }

--- a/src/it/it-source-kotlin-groovy/build.gradle
+++ b/src/it/it-source-kotlin-groovy/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 		mavenLocal()
 	}
 	dependencies {
-		classpath("name.valery1707.kaitai:kaitai-gradle-plugin:0.1.1")
+		classpath("name.valery1707.kaitai:kaitai-gradle-plugin:0.1.3-SNAPSHOT")
 	}
 }
 // */

--- a/src/it/it-source-kotlin-kotlin/build.gradle.kts
+++ b/src/it/it-source-kotlin-kotlin/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
 		mavenLocal()
 	}
 	dependencies {
-		classpath("name.valery1707.kaitai:kaitai-gradle-plugin:0.1.1")
+		classpath("name.valery1707.kaitai:kaitai-gradle-plugin:0.1.3-SNAPSHOT")
 	}
 }
 // */
@@ -22,7 +22,7 @@ buildscript {
 plugins {
 	java
 	id("nebula.kotlin") version "1.3.11"
-	id("name.valery1707.kaitai") version "0.1.1"
+	id("name.valery1707.kaitai") version "0.1.3-SNAPSHOT"
 }
 
 repositories {

--- a/src/main/groovy/name/valery1707/kaitai/GenerateTask.groovy
+++ b/src/main/groovy/name/valery1707/kaitai/GenerateTask.groovy
@@ -25,7 +25,7 @@ class GenerateTask extends DefaultTask {
 		}
 		//Add generated directory into Gradle's build scope
 		if (project.hasProperty("sourceSets")) {
-			def generatedRoot = output.toPath().resolve("src")
+			def generatedRoot = output.toPath()
 			(project.property("sourceSets") as SourceSetContainer)
 				.findByName("main")
 				?.java { it.srcDir(generatedRoot.toAbsolutePath().normalize().toString()) }

--- a/src/main/groovy/name/valery1707/kaitai/KaitaiExtension.groovy
+++ b/src/main/groovy/name/valery1707/kaitai/KaitaiExtension.groovy
@@ -25,7 +25,7 @@ class KaitaiExtension {
 	 *
 	 * @since 0.1.0
 	 */
-	String version = "0.8"
+	String version = "0.10"
 
 	/**
 	 * Cache directory for download KaiTai library.


### PR DESCRIPTION
Fixes #21  This removes the src folder from the sourceSet, fixing builds again. Note that this is independent of the maven changes, but those changes are required for testing, though I haven't figured out how to get the kotlin tests to pass (or even resolve) locally.

Additionally updates to 0.10 as default kaitai version